### PR TITLE
feat: export macros

### DIFF
--- a/extism-pdk.h
+++ b/extism-pdk.h
@@ -7,6 +7,11 @@ typedef uint64_t ExtismPointer;
 #define EXTISM_ENV_MODULE "extism:host/env"
 #define EXTISM_USER_MODULE "extism:host/user"
 
+#define EXTISM_EXPORT_AS(name) __attribute__((export_name(name)))
+#define EXTISM_EXPORTED_FUNCTION(name)                                         \
+  EXTISM_EXPORT_AS(#name)                                                      \
+  name
+
 #define IMPORT(a, b) __attribute__((import_module(a), import_name(b)))
 #define IMPORT_ENV(b)                                                          \
   __attribute__((import_module(EXTISM_ENV_MODULE), import_name(b)))
@@ -19,7 +24,8 @@ IMPORT_ENV("length")
 extern uint64_t extism_length(ExtismPointer);
 IMPORT_ENV("alloc")
 extern ExtismPointer extism_alloc(uint64_t);
-IMPORT_ENV("free") extern void extism_free(ExtismPointer);
+IMPORT_ENV("free")
+extern void extism_free(ExtismPointer);
 
 IMPORT_ENV("input_load_u8")
 extern uint8_t extism_input_load_u8(ExtismPointer);

--- a/extism-pdk.h
+++ b/extism-pdk.h
@@ -10,7 +10,7 @@ typedef uint64_t ExtismPointer;
 #define EXTISM_EXPORT_AS(name) __attribute__((export_name(name)))
 #define EXTISM_EXPORTED_FUNCTION(name)                                         \
   EXTISM_EXPORT_AS(#name)                                                      \
-  name
+  name(void)
 
 #define IMPORT(a, b) __attribute__((import_module(a), import_name(b)))
 #define IMPORT_ENV(b)                                                          \


### PR DESCRIPTION
The new macros `EXTISM_EXPORT_AS` and `EXTISM_EXPORTED_FUNCTION` enable easily exporting functions from code similar to how library functions are exported on other platforms, avoiding the need to modify linker flags to export functions.

For example:
```c
EXTISM_EXPORT_AS("count_vowels")
int32_t count_vowels(void) {...}
```

or even easier:

```c
int32_t EXTISM_EXPORTED_FUNCTION(count_vowels)(void){...}
```

I'm happy to make another PR updating the docs and examples if we think these methods should be the default way to export functions.

`EXTISM_EXPORT_AS` was intentionally not named `EXTISM_EXPORT` in-case something like `EMSCRIPTEN_KEEPALIVE` can be done some day, avoiding including the export name in the macro. Unfortunately, the technique used by `EMSCRIPTEN_KEEPALIVE` is not viable as it uses a special clang backend https://github.com/WebAssembly/tool-conventions/issues/64

