### PR TITLE
Feat: improve input loading and string handling

### DIFF
--- a/extism-pdk.h
+++ b/extism-pdk.h
@@ -19,116 +19,123 @@ typedef uint64_t ExtismPointer;
   __attribute__((import_module(EXTISM_USER_MODULE), import_name(b)))
 
 IMPORT_ENV("input_length")
-extern uint64_t extism_input_length();
+extern uint64_t extism_input_length(void);
 IMPORT_ENV("length")
-extern uint64_t extism_length(ExtismPointer);
+extern uint64_t extism_length(const ExtismPointer);
 IMPORT_ENV("alloc")
-extern ExtismPointer extism_alloc(uint64_t);
+extern ExtismPointer extism_alloc(const uint64_t);
 IMPORT_ENV("free")
 extern void extism_free(ExtismPointer);
-
 IMPORT_ENV("input_load_u8")
-extern uint8_t extism_input_load_u8(ExtismPointer);
+extern uint8_t extism_input_load_u8(const ExtismPointer);
 
 IMPORT_ENV("input_load_u64")
-extern uint64_t extism_input_load_u64(ExtismPointer);
+extern uint64_t extism_input_load_u64(const ExtismPointer);
 
 IMPORT_ENV("output_set")
-extern void extism_output_set(ExtismPointer, uint64_t);
+extern void extism_output_set(const ExtismPointer, const uint64_t);
 
 IMPORT_ENV("error_set")
-extern void extism_error_set(ExtismPointer);
+extern void extism_error_set(const ExtismPointer);
 
 IMPORT_ENV("config_get")
-extern ExtismPointer extism_config_get(ExtismPointer);
+extern ExtismPointer extism_config_get(const ExtismPointer);
 
 IMPORT_ENV("var_get")
-extern ExtismPointer extism_var_get(ExtismPointer);
+extern ExtismPointer extism_var_get(const ExtismPointer);
 
 IMPORT_ENV("var_set")
-extern void extism_var_set(ExtismPointer, ExtismPointer);
+extern void extism_var_set(ExtismPointer, const ExtismPointer);
 
 IMPORT_ENV("store_u8")
-extern void extism_store_u8(ExtismPointer, uint8_t);
+extern void extism_store_u8(ExtismPointer, const uint8_t);
 
 IMPORT_ENV("load_u8")
-extern uint8_t extism_load_u8(ExtismPointer);
+extern uint8_t extism_load_u8(const ExtismPointer);
 
 IMPORT_ENV("store_u64")
-extern void extism_store_u64(ExtismPointer, uint64_t);
+extern void extism_store_u64(ExtismPointer, const uint64_t);
 
 IMPORT_ENV("load_u64")
-extern uint64_t extism_load_u64(ExtismPointer);
+extern uint64_t extism_load_u64(const ExtismPointer);
 
 IMPORT_ENV("http_request")
-extern ExtismPointer extism_http_request(ExtismPointer, ExtismPointer);
+extern ExtismPointer extism_http_request(const ExtismPointer,
+                                         const ExtismPointer);
 
 IMPORT_ENV("http_status_code")
-extern int32_t extism_http_status_code();
+extern int32_t extism_http_status_code(void);
 
 IMPORT_ENV("log_info")
-extern void extism_log_info(ExtismPointer);
+extern void extism_log_info(const ExtismPointer);
 IMPORT_ENV("log_debug")
-extern void extism_log_debug(ExtismPointer);
+extern void extism_log_debug(const ExtismPointer);
 IMPORT_ENV("log_warn")
-extern void extism_log_warn(ExtismPointer);
+extern void extism_log_warn(const ExtismPointer);
 IMPORT_ENV("log_error")
-extern void extism_log_error(ExtismPointer);
+extern void extism_log_error(const ExtismPointer);
 
 // Load data from Extism memory
-static void extism_load(ExtismPointer offs, uint8_t *buffer, uint64_t length) {
-  uint64_t chunk_count = length >> 3;
-  uint64_t *i64_buffer = (uint64_t *)buffer;
-  for (uint64_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
+static void extism_load(const ExtismPointer offs, void *buffer,
+                        const size_t length) {
+  const size_t chunk_count = length >> 3;
+  uint64_t *i64_buffer = buffer;
+  for (size_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
     i64_buffer[chunk_idx] = extism_load_u64(offs + (chunk_idx << 3));
   }
 
-  uint64_t remainder = length & 7;
-  uint64_t remainder_offset = chunk_count << 3;
-  for (uint64_t index = remainder_offset;
-       index < (remainder + remainder_offset); index++) {
-    buffer[index] = extism_load_u8(offs + index);
+  size_t remainder_offset = chunk_count << 3;
+  const size_t remainder_end = remainder_offset + (length & 7);
+  for (uint8_t *u8_buffer = buffer; remainder_offset < remainder_end;
+       remainder_offset++) {
+    u8_buffer[remainder_offset] = extism_load_u8(offs + remainder_offset);
   }
 }
 
 // Load data from input buffer
-static void extism_load_input(uint8_t *buffer, uint64_t length) {
-  uint64_t chunk_count = length >> 3;
-  uint64_t *i64_buffer = (uint64_t *)buffer;
-  for (uint64_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
+static void extism_load_input(void *buffer, const size_t length) {
+  const size_t chunk_count = length >> 3;
+  uint64_t *i64_buffer = buffer;
+  for (size_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
     i64_buffer[chunk_idx] = extism_input_load_u64(chunk_idx << 3);
   }
 
-  uint64_t remainder = length & 7;
-  uint64_t remainder_offset = chunk_count << 3;
-  for (uint64_t index = remainder_offset;
-       index < (remainder + remainder_offset); index++) {
-    buffer[index] = extism_input_load_u8(index);
+  size_t remainder_offset = chunk_count << 3;
+  const size_t remainder_end = remainder_offset + (length & 7);
+  for (uint8_t *u8_buffer = buffer; remainder_offset < remainder_end;
+       remainder_offset++) {
+    u8_buffer[remainder_offset] = extism_input_load_u8(remainder_offset);
   }
 }
 
 // Copy data into Extism memory
-static void extism_store(ExtismPointer offs, const uint8_t *buffer,
-                         uint64_t length) {
-  uint64_t chunk_count = length >> 3;
-  uint64_t *i64_buffer = (uint64_t *)buffer;
-  for (uint64_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
+static void extism_store(ExtismPointer offs, const void *buffer,
+                         const size_t length) {
+  const size_t chunk_count = length >> 3;
+  const uint64_t *i64_buffer = buffer;
+  for (size_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
     extism_store_u64(offs + (chunk_idx << 3), i64_buffer[chunk_idx]);
   }
 
-  uint64_t remainder = length & 7;
-  uint64_t remainder_offset = chunk_count << 3;
-  for (uint64_t index = remainder_offset;
-       index < (remainder + remainder_offset); index++) {
-    extism_store_u8(offs + index, buffer[index]);
+  size_t remainder_offset = chunk_count << 3;
+  const size_t remainder_end = remainder_offset + (length & 7);
+  for (const uint8_t *u8_buffer = buffer; remainder_offset < remainder_end;
+       remainder_offset++) {
+    extism_store_u8(offs + remainder_offset, u8_buffer[remainder_offset]);
   }
 }
 
-// Allocate a string and copy the provided value into Extism memory
-static ExtismPointer extism_alloc_string(const char *s, uint64_t length) {
+// Allocate a buffer in Extism memory and copy into it
+static ExtismPointer extism_alloc_buf(const void *src, const size_t length) {
   ExtismPointer ptr = extism_alloc(length);
-  extism_store(ptr, (const uint8_t *)s, length);
+  extism_store(ptr, src, length);
   return ptr;
+}
+
+__attribute__((
+    deprecated("Use extism_alloc_buf instead."))) static inline ExtismPointer
+extism_alloc_string(const char *s, const size_t length) {
+  return extism_alloc_buf(s, length);
 }
 
 typedef enum {
@@ -139,9 +146,9 @@ typedef enum {
 } ExtismLog;
 
 // Write to Extism log
-static void extism_log(const char *s, uint64_t len, ExtismLog level) {
+static void extism_log(const char *s, const size_t len, const ExtismLog level) {
   ExtismPointer ptr = extism_alloc(len);
-  extism_store(ptr, (const uint8_t *)s, len);
+  extism_store(ptr, s, len);
   switch (level) {
   case ExtismLogInfo:
     extism_log_info(ptr);

--- a/extism-pdk.h
+++ b/extism-pdk.h
@@ -12,67 +12,67 @@ typedef uint64_t ExtismPointer;
   EXTISM_EXPORT_AS(#name)                                                      \
   name(void)
 
-#define IMPORT(a, b) __attribute__((import_module(a), import_name(b)))
-#define IMPORT_ENV(b)                                                          \
+#define EXTISM_IMPORT(a, b) __attribute__((import_module(a), import_name(b)))
+#define EXTISM_IMPORT_ENV(b)                                                   \
   __attribute__((import_module(EXTISM_ENV_MODULE), import_name(b)))
-#define IMPORT_USER(b)                                                         \
+#define EXTISM_IMPORT_USER(b)                                                  \
   __attribute__((import_module(EXTISM_USER_MODULE), import_name(b)))
 
-IMPORT_ENV("input_length")
+EXTISM_IMPORT_ENV("input_length")
 extern uint64_t extism_input_length(void);
-IMPORT_ENV("length")
+EXTISM_IMPORT_ENV("length")
 extern uint64_t extism_length(const ExtismPointer);
-IMPORT_ENV("alloc")
+EXTISM_IMPORT_ENV("alloc")
 extern ExtismPointer extism_alloc(const uint64_t);
-IMPORT_ENV("free")
+EXTISM_IMPORT_ENV("free")
 extern void extism_free(ExtismPointer);
-IMPORT_ENV("input_load_u8")
+EXTISM_IMPORT_ENV("input_load_u8")
 extern uint8_t extism_input_load_u8(const ExtismPointer);
 
-IMPORT_ENV("input_load_u64")
+EXTISM_IMPORT_ENV("input_load_u64")
 extern uint64_t extism_input_load_u64(const ExtismPointer);
 
-IMPORT_ENV("output_set")
+EXTISM_IMPORT_ENV("output_set")
 extern void extism_output_set(const ExtismPointer, const uint64_t);
 
-IMPORT_ENV("error_set")
+EXTISM_IMPORT_ENV("error_set")
 extern void extism_error_set(const ExtismPointer);
 
-IMPORT_ENV("config_get")
+EXTISM_IMPORT_ENV("config_get")
 extern ExtismPointer extism_config_get(const ExtismPointer);
 
-IMPORT_ENV("var_get")
+EXTISM_IMPORT_ENV("var_get")
 extern ExtismPointer extism_var_get(const ExtismPointer);
 
-IMPORT_ENV("var_set")
+EXTISM_IMPORT_ENV("var_set")
 extern void extism_var_set(ExtismPointer, const ExtismPointer);
 
-IMPORT_ENV("store_u8")
+EXTISM_IMPORT_ENV("store_u8")
 extern void extism_store_u8(ExtismPointer, const uint8_t);
 
-IMPORT_ENV("load_u8")
+EXTISM_IMPORT_ENV("load_u8")
 extern uint8_t extism_load_u8(const ExtismPointer);
 
-IMPORT_ENV("store_u64")
+EXTISM_IMPORT_ENV("store_u64")
 extern void extism_store_u64(ExtismPointer, const uint64_t);
 
-IMPORT_ENV("load_u64")
+EXTISM_IMPORT_ENV("load_u64")
 extern uint64_t extism_load_u64(const ExtismPointer);
 
-IMPORT_ENV("http_request")
+EXTISM_IMPORT_ENV("http_request")
 extern ExtismPointer extism_http_request(const ExtismPointer,
                                          const ExtismPointer);
 
-IMPORT_ENV("http_status_code")
+EXTISM_IMPORT_ENV("http_status_code")
 extern int32_t extism_http_status_code(void);
 
-IMPORT_ENV("log_info")
+EXTISM_IMPORT_ENV("log_info")
 extern void extism_log_info(const ExtismPointer);
-IMPORT_ENV("log_debug")
+EXTISM_IMPORT_ENV("log_debug")
 extern void extism_log_debug(const ExtismPointer);
-IMPORT_ENV("log_warn")
+EXTISM_IMPORT_ENV("log_warn")
 extern void extism_log_warn(const ExtismPointer);
-IMPORT_ENV("log_error")
+EXTISM_IMPORT_ENV("log_error")
 extern void extism_log_error(const ExtismPointer);
 
 // Load data from Extism memory

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,11 @@
 WASI_SDK_PATH?=../wasi-sdk
 
-test: test-alloc test-hello
+test: test-alloc test-hello test-load_input_bounds_checks test-strlen test-use_libc test-alloc_buf_from_sz
 run-fail: test-fail
-build: alloc hello fail
+build: alloc hello fail load_input_bounds_checks strlen use_libc alloc_buf_from_sz
+
+strlen use_libc:
+	$(WASI_SDK_PATH)/bin/clang --target=wasm32-wasi -o $@.wasm $@.c -mexec-model=reactor
 
 %: %.c
 	$(WASI_SDK_PATH)/bin/clang --target=wasm32-unknown-unknown -o $*.wasm $*.c -Wl,--no-entry -nostdlib

--- a/tests/alloc_buf_from_sz.c
+++ b/tests/alloc_buf_from_sz.c
@@ -2,10 +2,8 @@
 
 EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {
   const char *msg = "Hello, world!";
-  ExtismPointer ptr = extism_alloc(extism_strlen(msg));
+  ExtismPointer ptr = extism_alloc_buf_from_sz(msg);
   assert(ptr > 0);
-  extism_store(ptr, (const uint8_t *)msg, extism_strlen(msg));
   assert(extism_length(ptr) == extism_strlen(msg));
-  extism_output_set(ptr, extism_strlen(msg));
   return 0;
 }

--- a/tests/load_input_bounds_checks.c
+++ b/tests/load_input_bounds_checks.c
@@ -1,0 +1,13 @@
+#include "util.h"
+
+EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {
+  char c[2];
+  extism_load_input_unsafe(c, 0);
+  assert(extism_load_input(c, 0));
+  assert(!extism_load_input(c, 1));
+  extism_load_input_sz_unsafe(c, 1);
+  assert(!extism_load_input_sz(c, 0));
+  assert(extism_load_input_sz(c, 1));
+  assert(!extism_load_input_sz(c, 2));
+  return 0;
+}

--- a/tests/strlen.c
+++ b/tests/strlen.c
@@ -1,0 +1,9 @@
+#include "util.h"
+#include <string.h>
+
+EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {
+  const char *hello = "hello";
+  assert(strlen(hello) == extism_strlen(hello));
+  assert(strlen("") == extism_strlen(""));
+  return 0;
+}

--- a/tests/use_libc.c
+++ b/tests/use_libc.c
@@ -1,0 +1,24 @@
+#define EXTISM_USE_LIBC
+#include "util.h"
+
+EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {
+  void *input = extism_load_input_dup(NULL);
+  if (input != NULL) {
+    free(input);
+  }
+  size_t outSize;
+  if ((input = extism_load_input_dup(&outSize))) {
+    assert(outSize == 0);
+    free(input);
+  }
+  char *sz = extism_load_input_sz_dup(NULL);
+  assert(sz != NULL);
+  assert(*sz == '\0');
+  free(sz);
+  sz = extism_load_input_sz_dup(&outSize);
+  assert(sz != NULL);
+  assert(*sz == '\0');
+  assert(outSize == 1);
+  free(sz);
+  return 0;
+}

--- a/tests/util.h
+++ b/tests/util.h
@@ -6,14 +6,3 @@
   if (!(x)) {                                                                  \
     __builtin_unreachable();                                                   \
   }
-
-static unsigned long strlen(const char *s) {
-  unsigned long count = 0;
-
-  while (s && *s) {
-    s += 1;
-    count += 1;
-  }
-
-  return count;
-}


### PR DESCRIPTION
Resolves #14 

* namespace import macros
* take `void *` pointers to be more flexible
* improve input loading
  * check against `extism_input_length` and return `false` if too many bytes are requested
  * add convenience functions to load into zero terminated strings
  * add convenience functions to load input data into a `malloc`'d buffer (`strdup`-esque), requires `#define EXTISM_USE_LIBC`
* add convenience function to copy the contents of a zero terminated string into Extism memory. If `EXTISM_USE_LIBC` is not defined, it uses it's own `strlen` implementation.
