### PR TITLE
Feat: seperate implementation from interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.wasm
+*.o
 wasi-sdk

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This project contains a tool that can be used to create [Extism Plug-ins](https:
 
 ## Installation
 
-Since the Extism host provides these functions, all that's required to build a plugin with the Extism C PDK is the [extism-pdk.h](https://github.com/extism/c-pdk/blob/main/extism-pdk.h) header file. This can be copied into
-your project, or you can add the repo as a Git submodule:
+The Extism C PDK is a single header library. Just copy [extism-pdk.h](https://github.com/extism/c-pdk/blob/main/extism-pdk.h) into your project or add this repo as a Git submodule:
 
 ```shell
 git submodule add https://github.com/extism/c-pdk extism-pdk
@@ -21,6 +20,7 @@ The first thing you should understand is creating an export.
 Let's write a simple program that exports a `greet` function which will take a name as a string and return a greeting string. Paste this into a file `plugin.c`:
 
 ```c
+#define EXTISM_IMPLEMENTATION
 #include "extism-pdk.h"
 #include <stdint.h>
 
@@ -79,6 +79,7 @@ extism call plugin.wasm greet --input="Benjamin"
 We catch any exceptions thrown and return them as errors to the host. Suppose we want to re-write our greeting module to never greet Benjamins:
 
 ```c
+#define EXTISM_IMPLEMENTATION
 #include "extism-pdk.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -145,6 +146,7 @@ Configs are key-value pairs that can be passed in by the host when creating a
 plug-in. These can be useful to statically configure the plug-in with some data that exists across every function call. Here is a trivial example using `extism_config_get`:
 
 ```c
+#define EXTISM_IMPLEMENTATION
 #include "extism-pdk.h"
 #include <stdint.h>
 #include <stdlib.h>
@@ -204,6 +206,7 @@ host has loaded and not freed the plug-in.
 You can use `extism_var_get`, and `extism_var_set` to manipulate vars:
 
 ```c
+#define EXTISM_IMPLEMENTATION
 #include "extism-pdk.h"
 #include <stdint.h>
 
@@ -242,6 +245,7 @@ int32_t EXTISM_EXPORTED_FUNCTION(count) {
 The `extism_log*` functions can be used to emit logs:
 
 ```c
+#define EXTISM_IMPLEMENTATION
 #include "extism-pdk.h"
 #include <stdint.h>
 
@@ -273,6 +277,7 @@ extism call plugin.wasm log_stuff --log-level=info
 HTTP calls can be made using `extism_http_request`: 
 
 ```c
+#define EXTISM_IMPLEMENTATION
 #include "extism-pdk.h"
 #include <stdint.h>
 #include <string.h>
@@ -327,6 +332,7 @@ IMPORT("my_module", "a_python_func") extern ExtismPointer a_python_func(ExtismPo
 To call this function, we pass an Extism pointer and receive one back:
 
 ```c
+#define EXTISM_IMPLEMENTATION
 #include "extism-pdk.h"
 #include <stdint.h>
 
@@ -387,6 +393,21 @@ python3 app.py
 # => Hello from Python!
 # => An argument to send to Python!
 ```
+
+## Building
+
+One source file must contain the implementation:
+
+```c
+#define EXTISM_IMPLEMENTATION
+#include "extism-pdk.h"
+```
+
+All other source files using the pdk must include the header without `#define EXTISM_IMPLEMENTATION`
+
+The C PDK does not require building with `libc`, but additional functions can be enabled when `libc` is available. `#define EXTISM_USE_LIBC` in each file before including the pdk (everywhere it is included) or, when compiling, pass it as a flag to clang: `-D EXTISM_USE_LIBC`
+
+The C PDK may be used from C++, however, the implementation must be built with a C compiler. See `cplusplus` in `tests/Makefile` for an example.
 
 ## Exports (details)
 

--- a/examples/count-vowels/count-vowels.c
+++ b/examples/count-vowels/count-vowels.c
@@ -1,3 +1,4 @@
+#define EXTISM_IMPLEMENTATION
 #include "../../extism-pdk.h"
 
 #include <stdio.h>

--- a/examples/globals/globals.c
+++ b/examples/globals/globals.c
@@ -1,3 +1,4 @@
+#define EXTISM_IMPLEMENTATION
 #include "../../extism-pdk.h"
 
 #include <stdio.h>

--- a/examples/host-functions/host-functions.c
+++ b/examples/host-functions/host-functions.c
@@ -1,8 +1,9 @@
+#define EXTISM_IMPLEMENTATION
 #include "../../extism-pdk.h"
 
 #include <stdio.h>
 
-IMPORT("extism:host/user", "hello_world")
+EXTISM_IMPORT("extism:host/user", "hello_world")
 extern uint64_t hello_world(uint64_t);
 
 int32_t EXTISM_EXPORTED_FUNCTION(count_vowels) {

--- a/extism-pdk.h
+++ b/extism-pdk.h
@@ -129,6 +129,9 @@ typedef enum {
 // Write to Extism log
 void extism_log(const char *s, const size_t len, const ExtismLog level);
 
+// Write zero-terminated string to Extism log
+void extism_log_sz(const char *s, const ExtismLog level);
+
 #ifdef __cplusplus
 }
 #endif
@@ -305,6 +308,12 @@ void extism_log(const char *s, const size_t len, const ExtismLog level) {
     break;
   }
   extism_free(ptr);
+}
+
+// Write zero-terminated string to Extism log
+void extism_log_sz(const char *s, const ExtismLog level) {
+  const size_t len = extism_strlen(s);
+  extism_log(s, len, level);
 }
 
 #endif // extism_pdk_c

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,13 @@
 WASI_SDK_PATH?=../wasi-sdk
 
-test: test-alloc test-hello test-load_input_bounds_checks test-strlen test-use_libc test-alloc_buf_from_sz
+test: test-alloc test-hello test-load_input_bounds_checks test-strlen test-use_libc test-alloc_buf_from_sz test-cplusplus
 run-fail: test-fail
-build: alloc hello fail load_input_bounds_checks strlen use_libc alloc_buf_from_sz
+build: alloc hello fail load_input_bounds_checks strlen use_libc alloc_buf_from_sz cplusplus
+
+cplusplus:
+	$(WASI_SDK_PATH)/bin/clang++ --target=wasm32-wasi -c $@.cpp
+	$(WASI_SDK_PATH)/bin/clang --target=wasm32-wasi -c implementation.c
+	$(WASI_SDK_PATH)/bin/clang++ --target=wasm32-wasi -o $@.wasm $@.o implementation.o -mexec-model=reactor
 
 strlen use_libc:
 	$(WASI_SDK_PATH)/bin/clang --target=wasm32-wasi -o $@.wasm $@.c -mexec-model=reactor

--- a/tests/alloc_buf_from_sz.c
+++ b/tests/alloc_buf_from_sz.c
@@ -1,3 +1,4 @@
+#define EXTISM_IMPLEMENTATION
 #include "util.h"
 
 EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {

--- a/tests/cplusplus.cpp
+++ b/tests/cplusplus.cpp
@@ -1,0 +1,12 @@
+#include "util.h"
+#include <string.h>
+
+EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {
+  const char *msg = "Hello, world!";
+  ExtismPointer ptr = extism_alloc(strlen(msg));
+  assert(ptr > 0);
+  extism_store(ptr, (const uint8_t *)msg, strlen(msg));
+  assert(extism_length(ptr) == strlen(msg));
+  extism_output_set(ptr, strlen(msg));
+  return 0;
+}

--- a/tests/fail.c
+++ b/tests/fail.c
@@ -1,9 +1,10 @@
+#define EXTISM_IMPLEMENTATION
 #include "util.h"
 
 int32_t EXTISM_EXPORTED_FUNCTION(run_test) {
   const char *msg = "Some error message";
-  ExtismPointer ptr = extism_alloc(strlen(msg));
-  extism_store(ptr, (const uint8_t *)msg, strlen(msg));
+  ExtismPointer ptr = extism_alloc(extism_strlen(msg));
+  extism_store(ptr, (const uint8_t *)msg, extism_strlen(msg));
   extism_error_set(ptr);
   return 1;
 }

--- a/tests/hello.c
+++ b/tests/hello.c
@@ -1,3 +1,4 @@
+#define EXTISM_IMPLEMENTATION
 #include "util.h"
 
 EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {

--- a/tests/implementation.c
+++ b/tests/implementation.c
@@ -1,0 +1,2 @@
+#define EXTISM_IMPLEMENTATION
+#include "../extism-pdk.h"

--- a/tests/load_input_bounds_checks.c
+++ b/tests/load_input_bounds_checks.c
@@ -1,3 +1,4 @@
+#define EXTISM_IMPLEMENTATION
 #include "util.h"
 
 EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {

--- a/tests/strlen.c
+++ b/tests/strlen.c
@@ -1,3 +1,4 @@
+#define EXTISM_IMPLEMENTATION
 #include "util.h"
 #include <string.h>
 

--- a/tests/use_libc.c
+++ b/tests/use_libc.c
@@ -1,5 +1,7 @@
 #define EXTISM_USE_LIBC
+#define EXTISM_IMPLEMENTATION
 #include "util.h"
+#include <stdlib.h>
 
 EXTISM_EXPORT_AS("run_test") int32_t run_test(void) {
   void *input = extism_load_input_dup(NULL);


### PR DESCRIPTION
Resolves https://github.com/extism/c-pdk/issues/12

* Separated implementation from interface. It's still a single header library, but one compilation unit must `#define EXTISM_IMPLEMENTATION` before including `extism-pdk.h`
* C++ compat. Implementation still must be built with a C compiler, but it's the C pdk is now usable from C++.
* Added `BUILDING` section to README to cover `EXTISM_IMPLEMENTATION`, `EXTISM_USE_LIBC` and building with C++.
* Add `extism_log_sz`